### PR TITLE
instance method is not private

### DIFF
--- a/lib/monorails/per_thread_registry.rb
+++ b/lib/monorails/per_thread_registry.rb
@@ -1,5 +1,4 @@
 module ActiveSupport::PerThreadRegistry
-  private
 
   def instance
     @__instance ||= new


### PR DESCRIPTION
Getting a SystemStackError: stack level too deep using this + rails 4.1.9

see
https://github.com/rails/rails/blob/4-1-stable/activesupport/lib/active_support/per_thread_registry.rb#L39

Not sure how to add a regression test, I tried, however I think it is
hard to test this, as active_support will always be included before
monorails as rspec will include it. And if AS is before, the problem
will not happen.

(maybe we should change to test/unit for this gem.)
