### PR TITLE
Allow Rails 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
+*.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ gemfile:
   - gemfiles/Gemfile.ar-4.0
   - gemfiles/Gemfile.ar-4.1
   - gemfiles/Gemfile.ar-4.2
+  - gemfiles/Gemfile.ar-5.0

--- a/gemfiles/Gemfile.ar-5.0
+++ b/gemfiles/Gemfile.ar-5.0
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
+gem 'thread_hazardous', '~> 0.0.1'
+gem 'bundler', '~> 1.7'
+gem 'rake'
+gem 'rspec'

--- a/monorails.gemspec
+++ b/monorails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'thread_hazardous', '~> 0.0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Build is broken due a bug in Rails itself that we are going to fix.

```
Failures:

  1) ActiveSupport::PerThreadRegistry still forward methods just fine
     Failure/Error: expect(Registry.thruth).to be == 42

     NoMethodError:
       undefined method `delegate' for #<Class:Registry>
     # ./spec/per_thread_registry_spec.rb:22:in `block (2 levels) in <top (required)>'
```

One thing missing is that `thread_hazardous` doesn't work for Rails 5 because [it will ship with concurrent-ruby and not with thread_safe gem](https://github.com/rails/rails/commit/56ac6e4768adb1f7055474d40a9e921380559c43).
